### PR TITLE
When GTFS data is null, choose OSM data for New Value

### DIFF
--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/gui/object/BooleanMouseListener.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/gui/object/BooleanMouseListener.java
@@ -21,6 +21,7 @@ import java.awt.event.MouseEvent;
 import java.awt.event.MouseListener;
 import javax.swing.JTable;
 import javax.swing.table.TableColumnModel;
+import edu.usf.cutr.go_sync.gui.object.StopTableInfo;
 
 /**
  *
@@ -49,42 +50,66 @@ public class BooleanMouseListener implements MouseListener{
         if((dataValue!=null) && !(dataValue.equals(""))){
             Boolean otherCheckBox;
             String otherData, insertData=dataValue;
-            int otherColumn;
-            if(column==2) {
-                otherCheckBox = (Boolean)dataTable.getValueAt(row, column+2);
-                otherData = (String)dataTable.getValueAt(row, column+1);
-                if(otherData!=null && !(otherData.equals(""))) insertData = dataValue+";"+otherData;
-                otherColumn = column+2;
-            }
-            else {
-                otherCheckBox = (Boolean)dataTable.getValueAt(row, column-2);
-                otherData = (String)dataTable.getValueAt(row, column-3);
-                insertData = otherData+";"+dataValue;
-                otherColumn = column-2;
+            int otherCheckColumn;
+            int dataColumn = column - 1;
+            int otherDataColumn;
+
+            // look at data, checkBox info for other columns
+            // FIXME: needs some cleaning up for better readability
+            if(column==StopTableInfo.GTFS_CHECK_COL) {
+                otherCheckColumn = StopTableInfo.OSM_CHECK_COL;
+                otherDataColumn = otherCheckColumn - 1;
+                otherCheckBox = (Boolean)dataTable.getValueAt(row, otherCheckColumn);
+                otherData = (String)dataTable.getValueAt(row, otherDataColumn);
+                if(otherData!=null && !(otherData.equals("")))
+                    insertData = dataValue+";"+otherData;
+            } else { // column == StopTableInfo.OSM_CHECK_COL
+                otherCheckColumn = StopTableInfo.GTFS_CHECK_COL;
+                otherDataColumn = otherCheckColumn - 1;
+                otherCheckBox = (Boolean)dataTable.getValueAt(row, otherCheckColumn);
+                otherData = (String)dataTable.getValueAt(row, otherDataColumn);
+                if(otherCheckBox) {
+                    if (otherData!=null && !(otherData.equals("")))
+                        insertData = otherData+";"+dataValue;
+                    else {
+                        insertData = dataValue;
+                        otherCheckBox = false;
+                        otherData = "";
+                    }
+                } else {
+                    insertData = dataValue;
+                }
             }
 
-            if(row==0 || row==1){
+            if(row==0 || row==1){ // lat || lon
                 if((Boolean)currentValue) {
-                    dataTable.setValueAt(dataValue, row, 5);
-                    dataTable.setValueAt(new Boolean(false), row, otherColumn);
+                    dataTable.setValueAt(dataValue, row, StopTableInfo.NEW_VALUE_DATA_COL);
+                    dataTable.setValueAt(new Boolean(false), row, otherCheckColumn);
                 } else {
-                    dataTable.setValueAt(otherData, row, 5);
-                    dataTable.setValueAt(new Boolean(true), row, otherColumn);
+                    dataTable.setValueAt(otherData, row, StopTableInfo.NEW_VALUE_DATA_COL);
+                    dataTable.setValueAt(new Boolean(true), row, otherCheckColumn);
                 }
                 return;
             }
 
             if((Boolean)currentValue) {
-                if(otherCheckBox) dataTable.setValueAt(insertData, row, 5);
+                if(otherCheckBox)
+                    dataTable.setValueAt(insertData, row, StopTableInfo.NEW_VALUE_DATA_COL);
                 else {
-                    dataTable.setValueAt(dataValue, row, 5);
+                    dataTable.setValueAt(dataValue, row, StopTableInfo.NEW_VALUE_DATA_COL);
                 }
-            }
-            else {
-                if(otherCheckBox) dataTable.setValueAt(otherData, row, 5);
+            } else {
+                if(otherCheckBox)
+                    dataTable.setValueAt(otherData, row, StopTableInfo.NEW_VALUE_DATA_COL);
                 else {
-                    dataTable.setValueAt(new Boolean(true), row, otherColumn);
-                    dataTable.setValueAt(otherData, row, 5);
+                    if(otherData!=null && !(otherData.equals(""))) {
+                        dataTable.setValueAt(new Boolean(true), row, otherCheckColumn);
+                        dataTable.setValueAt(otherData, row, StopTableInfo.NEW_VALUE_DATA_COL);
+                    } else {
+                        dataTable.setValueAt(new Boolean(false), row, otherCheckColumn);
+                        dataTable.setValueAt(new Boolean(false), row, column);
+                        dataTable.setValueAt(otherData, row, StopTableInfo.NEW_VALUE_DATA_COL);
+                    }
                 }
             }
         }

--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/gui/object/StopTableInfo.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/gui/object/StopTableInfo.java
@@ -1,0 +1,36 @@
+/**
+Copyright 2010 University of South Florida
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+**/
+
+/**
+  * Reference to constants related to the StopTable
+  * The goal is to make it easier to interpret the meaning of different columns
+  * FIXME: Have other classes use these ints, rather than using hard coded numbers
+  */
+
+package edu.usf.cutr.go_sync.gui.object;
+
+/**
+  * @author Kevin Dalley
+  */
+
+public abstract class StopTableInfo {
+    static final int GTFS_DATA_COL = 1;
+    static final int GTFS_CHECK_COL = 2;
+    static final int OSM_DATA_COL = 3;
+    static final int OSM_CHECK_COL = 4;
+    static final int NEW_VALUE_DATA_COL = 5;
+};

--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/gui/object/TagReportTableModel.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/gui/object/TagReportTableModel.java
@@ -18,6 +18,7 @@ Copyright 2010 University of South Florida
 package edu.usf.cutr.go_sync.gui.object;
 
 import javax.swing.table.AbstractTableModel;
+import edu.usf.cutr.go_sync.gui.object.StopTableInfo;
 
 /**
  *
@@ -79,10 +80,13 @@ public class TagReportTableModel extends AbstractTableModel {
     @Override
     public boolean isCellEditable(int row, int col){
         // only the checkbox columns are editable
-        if(col==2 || col==4) {
-            String gtfs = (String)data[row][1];
-            String osm = (String)data[row][3];
-            if((gtfs==null) || (gtfs.equals("")) || (osm!=null && osm.contains(gtfs)))
+        if(col==StopTableInfo.GTFS_CHECK_COL || col==StopTableInfo.OSM_CHECK_COL) {
+            String gtfs = (String)data[row][StopTableInfo.GTFS_DATA_COL];
+            String osm = (String)data[row][StopTableInfo.OSM_DATA_COL];
+            // if gtfs is null/"", then we can still check the otfs value
+            if( ((gtfs==null) || (gtfs.equals(""))) && col == 2 )
+                return false;
+            if (gtfs != null && osm!=null && osm.contains(gtfs))
                 return false;
             if(osm!=null && osm.equals("")) return false;
 


### PR DESCRIPTION
When the GTFS value for a given row is null, the New Value is now set to
the OSM value by default.

It is now possible to click on the checkbox for OSM data, to make the
data blank, but it is not possible to click on the GTFS checkbox,
since that data is null (or empty)

close: #42