### PR TITLE
Fix #52 (#53)

### DIFF
--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/io/OsmPrinter.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/io/OsmPrinter.java
@@ -46,7 +46,7 @@ public class OsmPrinter {
         return "</create>\n" +
                 "<modify>\n";
     }
-    
+
     public String osmChangeDelete(){
         return "</modify>\n" +
                 "<delete>\n";
@@ -64,29 +64,38 @@ public class OsmPrinter {
                 "<tag k='comment' v='"+OsmFormatter.getValidXmlText(Session.getChangeSetComment())+"'/>\n" +
                 "</changeset>\n";
     }
-
+    //FIXME handle null changeIDs properly
     public String writeDeleteNode(String nodeID, String changeSetID, String version) {
-        return "<node id='"+nodeID+"' changeset='"+ changeSetID + "' version='"+ version +"' />\n";
+        String changesetText = " ";
+        if (!changeSetID.equals("DUMMY"))
+            changesetText = "changeset='" + changeSetID+ "'";
+        return "<node id='"+nodeID+ "' " + changesetText +  " version='"+ version +"' />\n";
     }
 
     public String writeBusStop(String changeSetID, String lat, String lon) {
-        return "<node changeset='" + changeSetID+ "' lat='" + lat + "' lon='" + lon + "'>\n" +
+        String changesetText = " ";
+        if (!changeSetID.equals("DUMMY"))
+            changesetText = "changeset='" + changeSetID+ "'";
+        return "<node " + changesetText +  " lat='" + lat + "' lon='" + lon + "'>\n" +
                 "<tag k='highway' v='bus_stop'/>\n" +
                 "</node>";
     }
 
     public String writeBusStop(String changeSetID, String nodeID, Stop st) {
+        String changesetText = " ";
+        if (!changeSetID.equals("DUMMY"))
+            changesetText = "changeset='" + changeSetID+ "'";
         String text="";
         Stop s = new Stop(st);
         // if modify, we need version number
         if(st.getOsmVersion()!=null) {
-            text += "<node changeset='" + changeSetID + "' id='" + nodeID
+            text += "<node " + changesetText + " id='" + nodeID
                     + "' lat='" + st.getLat() + "' lon='" + st.getLon()
                     + "' version='"+st.getOsmVersion() + "'>\n";
         }
         // mainly for create new node
         else {
-            text += "<node changeset='" + changeSetID + "' id='" + nodeID
+            text += "<node " + changesetText + " id='" + nodeID
                     + "' lat='" + st.getLat() + "' lon='" + st.getLon() + "'>\n";
             if(st.getTag(APPLICATION_CREATOR_KEY)!=null && !st.getTag(APPLICATION_CREATOR_KEY).equals("none")) {
                 text += "<tag k='"+APPLICATION_CREATOR_KEY+"' v='"+APPLICATION_CREATOR_NAME+"' />\n";
@@ -107,16 +116,19 @@ public class OsmPrinter {
     }
 
     public String writeBusRoute(String changeSetID, String routeID, Route r) {
+        String changesetText = " ";
+        if (!changeSetID.equals("DUMMY"))
+            changesetText = "changeset='" + changeSetID+ "'";
         String text="";
         Route route = new Route(r);
         // if modify, we need version number
         if(r.getOsmVersion()!=null) {
-            text += "<relation changeset='" + changeSetID + "' id='" + routeID
+            text += "<relation " + changesetText + " id='" + routeID
                     + "' version='"+route.getOsmVersion() + "'>\n";
         }
         // mainly for create new relation
         else {
-            text += "<relation changeset='" + changeSetID + "' id='" + routeID
+            text += "<relation  " + changesetText + "  id='" + routeID
                     + "' version='"+ routeID +"'>\n";
             text += "<tag k='"+APPLICATION_CREATOR_KEY+"' v='"+APPLICATION_CREATOR_NAME+"' />\n";
         }

--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/object/OsmPrimitive.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/object/OsmPrimitive.java
@@ -27,6 +27,7 @@ import java.util.Hashtable;
  */
 public class OsmPrimitive {
     Hashtable osmTags;
+    //TODO change reportCategory to enum
     private String status, osmVersion, osmid, reportCategory, reportText, lastEditedOsmUser="", lastEditedOsmDate="";
     public OsmPrimitive(){
         osmTags = new Hashtable();

--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/task/CompareData.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/task/CompareData.java
@@ -555,14 +555,14 @@ private ArrayList<Hashtable> OSMRelationTags = new ArrayList<Hashtable>();
             String routeShortName = (String)osmtag.get("ref");
             String operator = (String)osmtag.get("operator");  //tag_defs.GTFS_OPERATOR_KEY); //FIXME use tag_defs
             String network = (String)osmtag.get("network"); //(tag_defs.GTFS_NETWORK_KEY);    //FIXME use tag_defs
-            System.out.println(osm + " routeId " + routeId + routeKeys.contains(routeId) +  "routeShortName " + routeShortName + routeNameKeys.contains(routeShortName) + operator + network);
+//            System.out.println(osm + " routeId " + routeId + routeKeys.contains(routeId) +  "routeShortName " + routeShortName + routeNameKeys.contains(routeShortName) + operator + network);
             if((routeKeys.contains(routeId) ||routeNameKeys.contains(routeShortName))
                     && (
                     (operator!=null && OperatorInfo.isTheSameOperator(operator))||
                             (network!=null && OperatorInfo.isTheSameOperator(network))
             )
                     ) {
-                System.out.println(routeId +"\t" + operator);
+//                System.out.println(routeId +"\t" + operator);
                 HashSet<RelationMember> em = OSMRelationMembers.get(osm);
                 Route r;
                 String ostring,idstring,refstring;
@@ -1054,7 +1054,7 @@ private ArrayList<Hashtable> OSMRelationTags = new ArrayList<Hashtable>();
 
     public void generateReport(){
 
-    	System.out.println("GTFSstops "+ GTFSstops.size() + " report" + report.size() + "upload" + upload.size() + "modify" + modify.size() + "delete" + delete.size()  );
+        System.out.println("GTFSstops "+ GTFSstops.size() + " report:" + report.size() + " upload:" + upload.size() + " modify:" + modify.size() + " delete:" + delete.size()  );
 
         // copy report, where values are TreeSets,
         // to reportArrays, where values are ArrayLists

--- a/GO_Sync/src/main/resources/operators.csv
+++ b/GO_Sync/src/main/resources/operators.csv
@@ -625,3 +625,4 @@ Yuma Metropolitan Planning Organization ,YMPO,9192,,
 "QConnect (Yeppoon)",QConnect,,https://gtfsrt.api.translink.com.au/GTFS/YEP_GTFS.zip
 Translink SEQ,Translink,,https://gtfsrt.api.translink.com.au/GTFS/SEQ_GTFS.zip,
 Société de Transport de l'Outaouais,STO,,http://www.contenu.sto.ca/GTFS/GTFS.zip,
+Sociedade Transportes Colectivos do Porto,STCP,,https://opendata.urbanplatform.portodigital.pt/dataset/246720e7-5e96-47d9-86ba-d6e2956e6baa/resource/4be68555-5a0d-49d0-b62e-4e76735953a5/download/stcp-gtfs.zip


### PR DESCRIPTION
This fixes #52, as well a few minor enhancements relating to stop matching.

* Don't increment osmversion when saving data to final stops

* add Sociedade Transportes Colectivos do Porto to operators

* remove doubled uo confirmation dialogs

* Add TODO to OsmPrimitive

Add FIXME to ReportViewer

* Fix action button status after action

* refresh values when a new OSM stop selected in place of a previously accepted one

* Prevent overwriting of previously matched stops

* Add some more logging output

* remove routes debugging output

* Fix a few exceptions in reportviewer and add note about routes

* Don't export changeset if it is 'DUMMY'