### PR TITLE
Use Commons CSV and other changes (#54)

### DIFF
--- a/GO_Sync/pom.xml
+++ b/GO_Sync/pom.xml
@@ -34,6 +34,14 @@
 	<version>4aug2000r7-dev</version>
 </dependency>
 
+
+      <dependency>
+          <groupId>org.apache.commons</groupId>
+          <artifactId>commons-csv</artifactId>
+          <version>1.7</version>
+      </dependency>
+
+
   </dependencies>
 
 <build>
@@ -55,7 +63,7 @@
        </archive>
          </configuration>
      </plugin>
-<!--      
+<!--
 	TODO - This fails on Travis CI, so its commented out for now (see https://github.com/CUTR-at-USF/gtfs-osm-sync/pull/15#issuecomment-61645728)
 	  <plugin>
        <groupId>org.codehaus.mojo</groupId>
@@ -72,7 +80,7 @@
          </configuration>
         </execution>
        </executions>
-      </plugin>	    
+      </plugin>
 -->
 
 <plugin>
@@ -101,8 +109,8 @@
     <artifactId>maven-compiler-plugin</artifactId>
     <version>3.2</version>
     <configuration>
-      <source>1.7</source>
-      <target>1.7</target>
+      <source>1.8</source>
+      <target>1.8</target>
     </configuration>
   </plugin>
 </plugins>

--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/io/GTFSReadIn.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/io/GTFSReadIn.java
@@ -17,26 +17,23 @@ Copyright 2010 University of South Florida
 package edu.usf.cutr.go_sync.io;
 
 import java.io.*;
-import java.util.ArrayList;
-import java.util.HashSet;
-import java.util.Hashtable;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
+import java.util.regex.Pattern;
 
 import edu.usf.cutr.go_sync.tag_defs;
 import edu.usf.cutr.go_sync.object.OperatorInfo;
 import edu.usf.cutr.go_sync.object.Route;
 import edu.usf.cutr.go_sync.object.Stop;
 import edu.usf.cutr.go_sync.tools.OsmFormatter;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
 
 public class GTFSReadIn {
     private static Hashtable<String, Route> allRoutes;
-    private final String ROUTE_KEY = "route_ref";
-    private final String NTD_ID_KEY = "ntd_id";
+    private static final String ROUTE_KEY = "route_ref";
+    private static final String NTD_ID_KEY = "ntd_id";
     private static final String UTF8_BOM = "\uFEFF";
-//TODO read agency.txt
-    
 
     private List<Stop> stops;
 
@@ -50,76 +47,21 @@ public class GTFSReadIn {
         return allRoutes.keySet();
     }
 
-
-    public String readAgency(String agency_fName)
-    //public Hashtable<String, Route> readRoutes(String routes_fName)
-    {
-        String thisLine;
-        String [] elements;
-        int agencyIdKey=-1, agencyNameKey=-1;
+//TODO handle multiple agencies
+    public String readAgency(String agency_fName){
         try {
             BufferedReader br = new BufferedReader(new FileReader(agency_fName));
-            boolean isFirstLine = true;
-            Hashtable<String,Integer> keysIndex = new Hashtable<String,Integer>();
-            while ((thisLine = br.readLine()) != null) {
-                if (isFirstLine) {
-                    isFirstLine = false;
-                    thisLine = thisLine.replace("\"", "");
-                    String[] keys = thisLine.split(",");
-                    for(int i=0; i<keys.length; i++){
-                        if(keys[i].equals("agency_id")) agencyIdKey = i;
-                        else {
-                            if(keys[i].equals(tag_defs.GTFS_NETWORK_KEY)) agencyNameKey = i;
-                            String t = "gtfs_"+keys[i];
-                            keysIndex.put(t, i);
-                        }
-                    }
-//                    System.out.println(stopIdKey+","+stopNameKey+","+stopLatKey+","+stopLonKey);
-                }
-                else {
-                    boolean lastIndexEmpty=false;
-                    thisLine = thisLine.trim();
-                    if(thisLine.contains("\"")) {
-                         String[] temp = thisLine.split("\"");
-                         for(int x=0; x<temp.length; x++){
-                             if(x%2==1) temp[x] = temp[x].replace(",", "");
-                         }
-                         thisLine = "";
-                         for(int x=0; x<temp.length; x++){
-                             thisLine = thisLine + temp[x];
-                         }
-                    }
-                    elements = thisLine.split(",");
-                    if(thisLine.charAt(thisLine.length()-1)==',') lastIndexEmpty=true;
-                    String agencyName;
-                    if (elements[agencyNameKey] == null || elements[agencyNameKey].equals(""))
-                        agencyName = elements[agencyIdKey];
-                    else agencyName = elements[agencyNameKey];
+            CSVParser parser = CSVParser.parse(br, CSVFormat.DEFAULT.withHeader());
 
-                    br.close();
-                    return agencyName;
-                    /*
-                    Route r = new Route(elements[agencyIdKey], agencyName, OperatorInfo.getFullName());
-                    HashSet<String> keys = new HashSet<String>();
-                    keys.addAll(keysIndex.keySet());
-                    Iterator<String> it = keys.iterator();
-                    try {
-                        while(it.hasNext()){
-                            String k = (String)it.next();
-                            String v = null;
-                            if(!lastIndexEmpty) v = elements[(Integer)keysIndex.get(k)];
-                            if ((v!=null) && (!v.equals(""))) r.addTag(k, v);
-                        }
-                    } catch(Exception e){
-                        System.out.println("Error occurred! Please check your GTFS input files");
-                        System.out.println(e.toString());
-                        System.exit(0);
-                    }
-                    routes.put(elements[agencyIdKey], r);
-                    */
-                }
+            for (CSVRecord csvRecord : parser) {
+                String agencyName;
+                if (csvRecord.get(tag_defs.GTFS_NETWORK_KEY) == null ||
+                    csvRecord.get(tag_defs.GTFS_NETWORK_KEY).isEmpty())
+                    agencyName = csvRecord.get(tag_defs.GTFS_NETWORK_ID_KEY);
+                else agencyName = csvRecord.get(tag_defs.GTFS_NETWORK_KEY);
+                br.close();
+                return agencyName;
             }
-            br.close();
         }
         catch (IOException e) {
             System.err.println("Error: " + e);
@@ -129,27 +71,27 @@ public class GTFSReadIn {
     }
 
     public List<Stop> readBusStop(String fName, String agencyName, String routes_fName, String trips_fName, String stop_times_fName){
-        Hashtable<String, HashSet<Route>> stopIDs = new Hashtable<String, HashSet<Route>>();
+        long tStart = System.currentTimeMillis();
         Hashtable<String, HashSet<Route>> id = matchRouteToStop(routes_fName, trips_fName, stop_times_fName);
-        stopIDs.putAll(id);
+        Hashtable<String, HashSet<Route>> stopIDs = new Hashtable<String, HashSet<Route>>(id);
 
         String thisLine;
         String [] elements;
         int stopIdKey=-1, stopNameKey=-1, stopLatKey=-1, stopLonKey=-1;
         try {
             BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(fName),"UTF-8"));
-            boolean isFirstLine = true;
-            Hashtable<String,Integer> keysIndex = new Hashtable<String,Integer>();
-            while ((thisLine = br.readLine()) != null) {
-                if (isFirstLine) {
-                    isFirstLine = false;
-                    if (thisLine.startsWith(UTF8_BOM)) {
-                        thisLine = thisLine.substring(1);
-                    }
-                    OperatorInfo.setGtfsFields(thisLine);
-                    thisLine = thisLine.replace("\"", "");
-                    String[] keys = thisLine.split(",");
-                    for(int i=0; i<keys.length; i++){
+            HashMap<String,Integer> keysIndex = new HashMap<String,Integer> ();
+            thisLine = br.readLine();
+            StringReader sr = new StringReader(thisLine);
+            CSVParser headerParser = CSVParser.parse(sr, CSVFormat.DEFAULT.withHeader(
+                    //"route_id","route_short_name","route_long_name","route_desc","route_type","route_url","color","route_text_color"
+            ));
+
+            List<String> CSVkeysList = headerParser.getHeaderNames();
+            ArrayList<String> CSVkeysListNew = new ArrayList<>(CSVkeysList);
+            String[] keys =  new String[CSVkeysList.size()];
+            keys = CSVkeysList.toArray(keys);{
+                    for(int i=0; i<keys.length; i++) {
                         switch (keys[i]) {
                             case "stop_id":
                                 stopIdKey = i;
@@ -178,48 +120,32 @@ public class GTFSReadIn {
                             default:
                                 String t = "gtfs_" + keys[i];
                                 keysIndex.put(t, i);
-
                         }
                     }
                     System.out.println(keysIndex.toString());
 //                    System.out.println(stopIdKey+","+stopNameKey+","+stopLatKey+","+stopLonKey);
                 }
-                else {
-                    boolean lastIndexEmpty=false;
-                    thisLine = thisLine.trim();
-
-                    if(thisLine.contains("\"")) {
-                         String[] temp = thisLine.split("\"");
-                         for(int x=0; x<temp.length; x++){
-                             if(x%2==1) temp[x] = temp[x].replace(",", "");
-                         }
-                         thisLine = "";
-                         for(int x=0; x<temp.length; x++){
-                             thisLine = thisLine + temp[x];
-                         }
-                    }
-                    elements = thisLine.split(",");
-                    //System.out.println(elements.length);
-                   // for (int zxc = 0; zxc< elements.length-1; zxc++) {System.out.print(elements[zxc]+ ",");}System.out.print(elements[elements.length] );
-                    if(thisLine.charAt(thisLine.length()-1)==',') lastIndexEmpty=true;
-                    //add leading 0's to gtfs_id
+            CSVParser parser = CSVParser.parse(br, CSVFormat.DEFAULT.withHeader(keys));
+            for (CSVRecord csvRecord : parser) {
+                Iterator<String> iter = csvRecord.iterator();
+                Map<String,String> hm = csvRecord.toMap();
+                elements =  new String[hm.size()];
+                elements = hm.values().toArray(elements);
+                 //add leading 0's to gtfs_id
                     String tempStopId = OsmFormatter.getValidBusStopId(elements[stopIdKey]);
                     Stop s = new Stop(tempStopId, agencyName, elements[stopNameKey],elements[stopLatKey],elements[stopLonKey]);
-                    HashSet<String> keys = new HashSet<String>();
-                    keys.addAll(keysIndex.keySet());
-                    Iterator it = keys.iterator();
+                    HashSet<String> keysn = new HashSet<String>(keysIndex.keySet());
+                    Iterator it = keysn.iterator();
                     try {
-                        while(it.hasNext()){
+                        while(it.hasNext()) {
                         	String k = (String)it.next();
 
                             String v = null;
                             //if(!lastIndexEmpty) v = elements[(Integer)keysIndex.get(k)];
                             if(keysIndex.get(k) < elements.length) v = elements[keysIndex.get(k)];
-                            if ((v!=null) && (!v.equals(""))) {
-                                if (k.equals(tag_defs.OSM_STOP_TYPE_KEY))
-                                {
-                                    switch(Integer.parseInt(v))
-                                    {
+                            if ((v!=null) && (!v.isEmpty())) {
+                                if (k.equals(tag_defs.OSM_STOP_TYPE_KEY)) {
+                                    switch(Integer.parseInt(v)) {
                                         // https://developers.google.com/transit/gtfs/reference/stops-file
                                         case 0: v="platform";break;
                                         case 1: v="station"; break;
@@ -229,7 +155,7 @@ public class GTFSReadIn {
                                 if (k.equals(tag_defs.OSM_WHEELCHAIR_KEY)) {
                                     String parent = "";
 
-                                    if (keys.contains("gtfs_parent_station"))
+                                    if (keysn.contains("gtfs_parent_station"))
                                         parent = elements[keysIndex.get(k)];
                                     if (parent.isEmpty()) {
                                         switch (Integer.parseInt(v)) {
@@ -248,33 +174,19 @@ public class GTFSReadIn {
                                         }
                                         s.addTag(k, v);
                                     }
-
-
                                 } else
-
                                     s.addTag(k, v);
                             }
                             //System.out.print(k+":" + v +" ");
-
                         }
 //                        s.addTag(NTD_ID_KEY, OperatorInfo.getNTDID());
 //                        s.addTag("url", s.getTag("stop_url"));
-                     /*   if (!(s.getTag(tag_defs.GTFS_NAME_KEY).contains("platform") || s.getTag(tag_defs.GTFS_STOP_ID_KEY).contains("place")))
-                        		{
-                        	s.addTag("highway", "bus_stop");
-                        	s.addTag("bus", "yes");
-                        		}
-                        if (s.getTag(tag_defs.GTFS_STOP_ID_KEY).contains("place"))
-                        	s.addTag("public_transport", "station");
-                        else
-                        	s.addTag("public_transport", "platform");*/
 
-//if (s.getTag("gtfs_location_type");)
-
-// disable source tag                        s.addTag("source", "http://translink.com.au/about-translink/reporting-and-publications/public-transport-performance-data");
+// disable source tag
+//                        s.addTag("source", "http://translink.com.au/about-translink/reporting-and-publications/public-transport-performance-data");
 //                        if (!tempStopId.contains("place")) s.addTag("url", "http://translink.com.au/stop/"+tempStopId);
 
-                    } catch(Exception e){
+                    } catch(Exception e) {
                         System.out.println("Error occurred! Please check your GTFS input files");
                         System.out.println(e.toString());
                         System.exit(0);
@@ -290,22 +202,21 @@ public class GTFSReadIn {
 
                     stops.add(s);
 
-
+                    HashMap<String,String> modes = getModeTagsByBusStop(stopIDs.get(tempStopId));
+                    if (!r.isEmpty()) s.addTags(modes);
 //                    System.out.println(thisLine);
                 }
-            }
+//            }
         }
         catch (IOException e) {
             System.err.println("Error: " + e);
         }
+        long tDelta = System.currentTimeMillis() - tStart;
+//        this.setMessage("Completed in "+ tDelta /1000.0 + "seconds");
+        System.out.println("GTFSReadIn Completed in "+ tDelta /1000.0 + "seconds");
         return stops;
     }
 
-    /*
-
-
-
-     */
     public Hashtable<String, Route> readRoutes(String routes_fName){
         Hashtable<String, Route> routes = new Hashtable<String, Route>();
         String thisLine;
@@ -314,94 +225,88 @@ public class GTFSReadIn {
 
         try {
             BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(routes_fName),"UTF-8"));
-            boolean isFirstLine = true;
-            Hashtable<String,Integer> keysIndex = new Hashtable<String,Integer> ();
-            while ((thisLine = br.readLine()) != null) {
-                if (isFirstLine) {
-                    isFirstLine = false;
-                    if (thisLine.startsWith(UTF8_BOM)) {
-                        thisLine = thisLine.substring(1);
-                    }
-                    thisLine = thisLine.replace("\"", "");
-                    String[] keys = thisLine.split(",");
-                    //map GTFS keys to OSM keys
-                    for(int i=0; i<keys.length; i++){
-                        //read keys
-                        switch (keys[i]) {
-                            case "route_id":
-                                routeIdKey = i;
-                                break;
-                            case tag_defs.GTFS_ROUTE_URL_KEY:
-                                keysIndex.put(tag_defs.OSM_URL_KEY, i);
-                                break;
-                            case "route_type":
-                                keysIndex.put(tag_defs.OSM_ROUTE_TYPE_KEY, i);
-                                break;
-                            case tag_defs.GTFS_COLOUR_KEY:
-                                keysIndex.put(tag_defs.OSM_COLOUR_KEY, i);
-                                break;
-                            case tag_defs.GTFS_ROUTE_NUM:
-                                routeShortNameKey = i;
-                                break;
-                            case tag_defs.GTFS_ROUTE_NAME:
-                                routeLongNameKey = i;
-                                break;
-                            default:
-                                String t = "gtfs_" + keys[i];
-                                keysIndex.put(t, i);
-                                break;
-                        }
-
-                    }
-                    if (routeLongNameKey != -1)
-                        keysIndex.put("name",routeLongNameKey);
-//                    System.out.println(stopIdKey+","+stopNameKey+","+stopLatKey+","+stopLonKey);
+            HashMap<String,Integer> keysIndex = new HashMap<String,Integer> ();
+            thisLine = br.readLine();
+            StringReader sr = new StringReader(thisLine);
+            CSVParser headerParser = CSVParser.parse(sr, CSVFormat.DEFAULT.withHeader(
+                    //"route_id","route_short_name","route_long_name","route_desc","route_type","route_url","color","route_text_color"
+            ));
+            List<String> CSVkeysList = headerParser.getHeaderNames();
+            ArrayList<String> CSVkeysListNew = new ArrayList<>(CSVkeysList);
+            String[] keysn =  new String[CSVkeysList.size()];
+            keysn = CSVkeysList.toArray(keysn);
+            for(int i=0; i<keysn.length; i++) {
+                //read keys
+                switch (keysn[i]) {
+                    case tag_defs.GTFS_ROUTE_ID_KEY:
+                        routeIdKey = i;
+                        break;
+                    case tag_defs.GTFS_ROUTE_URL_KEY:
+                        keysIndex.put(tag_defs.OSM_URL_KEY, i);
+                        break;
+                    case "route_type":
+                        keysIndex.put(tag_defs.OSM_ROUTE_TYPE_KEY, i);
+                        break;
+                    case tag_defs.GTFS_COLOUR_KEY:
+                    case tag_defs.GTFS_COLOR_KEY:
+                        keysIndex.put(tag_defs.OSM_COLOUR_KEY, i);
+                        break;
+                    case tag_defs.GTFS_ROUTE_NUM:
+                        routeShortNameKey = i;
+                        break;
+                    case tag_defs.GTFS_ROUTE_NAME:
+                        routeLongNameKey = i;
+                        break;
+                    default:
+                        String t = "gtfs_" + keysn[i];
+                        keysIndex.put(t, i);
+                        break;
                 }
-                else {
-                    boolean lastIndexEmpty=false;
-                    thisLine = thisLine.trim();
-                    if(thisLine.contains("\"")) {
-                         String[] temp = thisLine.split("\"");
-                         for(int x=0; x<temp.length; x++){
-                             if(x%2==1) temp[x] = temp[x].replace(",", "");
-                         }
-                         thisLine = "";
-                         for(int x=0; x<temp.length; x++){
-                             thisLine = thisLine + temp[x];
-                         }
-                    }
-                    elements = thisLine.split(",");
-                    if(thisLine.charAt(thisLine.length()-1)==',') lastIndexEmpty=true;
+            }
+            if (routeLongNameKey != -1)
+                keysIndex.put("name",routeLongNameKey);
+//                    System.out.println(stopIdKey+","+stopNameKey+","+stopLatKey+","+stopLonKey);
+
+            {
+                final Pattern colourPattern = Pattern.compile("^[a-fA-F0-9]+$");
+                CSVParser parser = CSVParser.parse(br, CSVFormat.DEFAULT.withHeader(keysn));
+                for (CSVRecord csvRecord : parser) {
+
+                    Iterator<String> iter = csvRecord.iterator();
+                    Map<String,String> hm = csvRecord.toMap();
+                    elements =  new String[hm.size()];
+                    elements = hm.values().toArray(elements);
+
                     String routeName;
-                    if(elements[routeShortNameKey]==null || elements[routeShortNameKey].equals("")) routeName = elements[routeIdKey];
+                    if(elements[routeShortNameKey]==null || elements[routeShortNameKey].isEmpty()) routeName = elements[routeIdKey];
                     else routeName = elements[routeShortNameKey];
                     Route r = new Route(elements[routeIdKey], routeName, OperatorInfo.getFullName());
-                    HashSet<String> keys = new HashSet<String>();
-                    keys.addAll(keysIndex.keySet());
+                    HashSet<String> keys = new HashSet<String>(keysIndex.keySet());
                     Iterator<String> it = keys.iterator();
                     try {
-                        while(it.hasNext()){
+                        while(it.hasNext()) {
                             String k = it.next();
                             String v = null;
-                            if(!lastIndexEmpty) v = elements[keysIndex.get(k)];
-                            if ((v!=null) && (!v.equals("")))
-                            {
-                                if (k.equals(tag_defs.OSM_ROUTE_TYPE_KEY))
-                                {
+                            int ki = keysIndex.get(k);
+                            if(/*!(lastIndexEmpty && */ki <elements.length) v = elements[ki];
+                            if ((v!=null) && (!v.isEmpty())) {
+                                if (k.equals(tag_defs.OSM_ROUTE_TYPE_KEY)) {
                                     String route_value;
-                                    switch(Integer.parseInt(v))
-                                    {
+                                    switch(Integer.parseInt(v)) {
                                         // TODO allow drop down finetuning selection on report viewer
                                         // https://developers.google.com/transit/gtfs/reference/routes-file
                                         // https://wiki.openstreetmap.org/wiki/Relation:route#Route_types_.28route.29
                                         case 0: route_value = "light_rail";	break;// 0: Tram, Streetcar, Light rail. Any light rail or street level system within a metropolitan area.
                                         case 1:	route_value = "subway";     break;	// Subway, Metro. Any underground rail system within a metropolitan area.
-                                        case 2: route_value = "railway";    break;	// Rail. Used for intercity or long-distance travel.
+                                        case 2: route_value = "train";      break;	// Rail. Used for intercity or long-distance travel.
                                         case 3: route_value = "bus";        break;	// Bus. Used for short- and long-distance bus routes.
                                         case 4: route_value = "ferry";      break;	// Ferry. Used for short- and long-distance boat service.
-                                        case 5: route_value = "cable_car";  break;	// Cable car. Used for street-level cable cars where the cable runs beneath the car.
-                                        case 6: route_value = "gondola";    break;	// Gondola, Suspended cable car. Typically used for aerial cable cars where the car is suspended from the cable.
-                                        case 7: route_value = "funicular";  break;	// Funicular. Any rail system designed for steep inclines.
+                                        case 5: route_value = "tram";       break;	// Cable car. Used for street-level cable cars where the cable runs beneath the car.
+                                        case 6: k = "aerialway";
+                                                route_value = "yes";        break;	// Gondola, Suspended cable car. Typically used for aerial cable cars where the car is suspended from the cable.
+                                        // TODO use railway=funicular
+                                        case 7: k = "railway";
+                                                route_value = "funicular";  break;	// Funicular. Any rail system designed for steep inclines.
                                         default: route_value = v; break;
                                     }
                                     v = route_value;
@@ -409,12 +314,9 @@ public class GTFSReadIn {
                                 //prepend hex colours
 //                                if (k.equals(tag_defs.OSM_COLOUR_KEY))
 //                                    System.out.println(tag_defs.OSM_COLOUR_KEY + " "+ v + " #"+v);
-                                if (k.equals(tag_defs.OSM_COLOUR_KEY) && ((v.length() == 3 || v.length() == 6) && v.matches("^[a-fA-F0-9]+$")) )
-                                {
+                                if (k.equals(tag_defs.OSM_COLOUR_KEY) && ((v.length() == 3 || v.length() == 6) && colourPattern.matcher(v).matches()))/*^[a-fA-F0-9]+$")))*/ {
                                     v = "#".concat(v);
                                 }
-
-
                                 r.addTag(k, v);
                             }
                         }
@@ -435,47 +337,20 @@ public class GTFSReadIn {
 
     public Hashtable<String, HashSet<Route>> matchRouteToStop(String routes_fName, String trips_fName, String stop_times_fName){
         allRoutes.putAll(readRoutes(routes_fName));
-        String thisLine;
-        String [] elements;
-        // hashtable String vs. String
-        Hashtable<String,String> tripIDs = new Hashtable<String,String>();
+        HashMap<String,String> tripIDs = new HashMap<String,String>();
 
         // trips.txt read-in
         try {
-            int tripIdKey=-1, routeIdKey=-1;
             BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(trips_fName),"UTF-8"));
-            boolean isFirstLine = true;
-            while ((thisLine = br.readLine()) != null) {
-                if (isFirstLine) {
-                    isFirstLine = false;
-                    if (thisLine.startsWith(UTF8_BOM)) {
-                        thisLine = thisLine.substring(1);
-                    }
-                    thisLine = thisLine.replace("\"", "");
-                    String[] keys = thisLine.split(",");
-                    for(int i=0; i<keys.length; i++){
-                        if(keys[i].equals("route_id")) routeIdKey = i;
-                        else if(keys[i].equals("trip_id")) tripIdKey = i;
-                    }
+            CSVParser parser = CSVParser.parse(br, CSVFormat.DEFAULT.withHeader());
+            for (CSVRecord csvRecord : parser) {
+
+                String tripId = csvRecord.get(tag_defs.GTFS_TRIP_ID_KEY);
+                // not sure if tripId is unique in trips.txt, e.g. can 1 trip_id has multiple route_id
+                if (tripIDs.containsKey(tripId)) {
+                    System.out.println("Repeat "+tripId);
                 }
-                else {
-                    if(thisLine.contains("\"")) {
-                         String[] temp = thisLine.split("\"");
-                         for(int x=0; x<temp.length; x++){
-                             if(x%2==1) temp[x] = temp[x].replace(",", "");
-                         }
-                         thisLine = "";
-                         for(int x=0; x<temp.length; x++){
-                             thisLine = thisLine + temp[x];
-                         }
-                    }
-                    elements = thisLine.split(",");
-                    // not sure if tripId is unique in trips.txt, e.g. can 1 trip_id has multiple route_id
-                    if (tripIDs.containsKey(elements[tripIdKey])) {
-                        System.out.println("Repeat "+elements[tripIdKey]);
-                    }
-                    tripIDs.put(elements[tripIdKey], elements[routeIdKey]);
-                }
+                tripIDs.put(tripId, csvRecord.get(tag_defs.GTFS_ROUTE_ID_KEY));
             }
         }
         catch (IOException e) {
@@ -485,47 +360,24 @@ public class GTFSReadIn {
         // hashtable String(stop_id) vs. HashSet(routes)
         Hashtable<String, HashSet<Route>> stopIDs = new Hashtable<String, HashSet<Route>>();
         // stop_times.txt read-in
-        int stopIdKey=-1, tripIdKey = -1;
         try {
-            BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(stop_times_fName),"UTF-8"));
-            boolean isFirstLine = true;
-            while ((thisLine = br.readLine()) != null) {
-                if (isFirstLine) {
-                    isFirstLine = false;
-                    if (thisLine.startsWith(UTF8_BOM)) {
-                        thisLine = thisLine.substring(1);
-                    }
-                    thisLine = thisLine.replace("\"", "");
-                    String[] keys = thisLine.split(",");
-                    for(int i=0; i<keys.length; i++){
-                        if(keys[i].equals("stop_id")) stopIdKey = i;
-                        else if(keys[i].equals("trip_id")) tripIdKey = i;
-                    }
+            BufferedReader br = new BufferedReader(new InputStreamReader(new FileInputStream(stop_times_fName), "UTF-8"));
+
+            CSVParser parser = CSVParser.parse(br, CSVFormat.DEFAULT.withHeader());
+
+            for (CSVRecord csvRecord : parser) {
+                // This seems to be the fastest method using csvparser
+                String trip = csvRecord.get(tag_defs.GTFS_TRIP_ID_KEY);
+                HashSet<Route> routes = new HashSet<Route>();
+                Route tr = null;
+                if (tripIDs.get(trip) != null) tr = allRoutes.get(tripIDs.get(trip));
+                if (tr != null) routes.add(tr);
+                String sid = OsmFormatter.getValidBusStopId(csvRecord.get(tag_defs.GTFS_TRIPS_STOP_ID_KEY));
+                if (stopIDs.containsKey(sid)) {
+                    routes.addAll(stopIDs.get(sid));
+                    stopIDs.remove(sid);
                 }
-                else {
-                    if(thisLine.contains("\"")) {
-                         String[] temp = thisLine.split("\"");
-                         for(int x=0; x<temp.length; x++){
-                             if(x%2==1) temp[x] = temp[x].replace(",", "");
-                         }
-                         thisLine = "";
-                         for(int x=0; x<temp.length; x++){
-                             thisLine = thisLine + temp[x];
-                         }
-                    }
-                    elements = thisLine.split(",");
-                    String trip = elements[tripIdKey];
-                    HashSet<Route> routes = new HashSet<Route>();
-                    Route tr = null;
-                    if(tripIDs.get(trip) !=null) tr = allRoutes.get(tripIDs.get(trip));
-                    if(tr!=null) routes.add(tr);
-                    String sid = OsmFormatter.getValidBusStopId(elements[stopIdKey]);
-                    if (stopIDs.containsKey(sid)) {
-                        routes.addAll(stopIDs.get(sid));
-                        stopIDs.remove(sid);
-                    }
-                    stopIDs.put(sid, routes);
-                }
+                stopIDs.put(sid, routes);
             }
         }
         catch (IOException e) {
@@ -534,37 +386,50 @@ public class GTFSReadIn {
         return stopIDs;
     }
 
+    //TODO implement  this
+    // https://wiki.openstreetmap.org/wiki/Public_transport
+    public HashMap<String,String> getModeTagsByBusStop(HashSet<Route> r) {
+        HashMap<String,String> keys = new HashMap<String,String>();
+        if (r!=null) {
+            //convert from hashset to arraylist
+            ArrayList<Route> routes = new ArrayList<Route>(r);
+            for (Route rr:routes) {
+                if (rr.containsKey(tag_defs.OSM_ROUTE_TYPE_KEY)) {
+                    keys.put(rr.getTag(tag_defs.OSM_ROUTE_TYPE_KEY), "yes");
+                    if (rr.getTag(tag_defs.OSM_ROUTE_TYPE_KEY) == "ferry")
+                        keys.put("amenity","ferry_terminal");
+                }
+                if (rr.containsKey("aerialway"))
+                     keys.put("aerialway","station");
+                if (rr.containsKey("railway") && rr.getTag("railway") == "funicular") {
+                    keys.put("railway","station");
+                    keys.put("station","funicular");
+                }
+            }
+        }
+        return keys;
+    }
+
+    private class hashCodeCompare implements  Comparator
+    {
+        @Override
+        public int compare(Object o, Object t1) {
+            return o.hashCode() - t1.hashCode();
+        }
+    }
+
     public String getRoutesInTextByBusStop(HashSet<Route> r) {
         String text="";
-        if (r!=null) {
-            ArrayList<Route> routes = new ArrayList<Route>();
-            //convert from hashset to arraylist
-            routes.addAll(r);
-            //ordering by hashcode
-            for (int i=0; i<routes.size()-1; i++) {
-                int k=i;
-                for (int j=i+1; j<routes.size(); j++) {
-                    if (routes.get(k).getRouteRef().hashCode() > routes.get(j).getRouteRef().hashCode()) {
-                        k = j;
-                    }
-                }
-                Route temp = routes.get(i);
-                routes.set(i, routes.get(k));
-                routes.set(k, temp);
-            }
 
-            //to text
-            for (int i=0; i<routes.size(); i++) {
-                text = text + ";" + routes.get(i).getRouteRef();
+        if (r!=null) {
+            TreeSet<String> routeRefSet = new TreeSet<String>(new hashCodeCompare());
+            //convert from hashset to arraylist
+            ArrayList<Route> routes = new ArrayList<Route>(r);
+            for (Route rr:routes) {
+                routeRefSet.add(rr.getRouteRef());
             }
-            //delete the 1st semi-colon
-            if (!text.isEmpty()) {
-                text = text.substring(1);
-            }
+            text = String.join(";",routeRefSet);
         }
         return text;
     }
-
-
-
 }

--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/object/OsmPrimitive.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/object/OsmPrimitive.java
@@ -18,6 +18,8 @@ Copyright 2010 University of South Florida
 package edu.usf.cutr.go_sync.object;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.HashSet;
 import java.util.Hashtable;
 
@@ -49,6 +51,17 @@ public class OsmPrimitive {
      * since we don't want the new data overwrite the old one. Use addAndOverwriteTags instead
      * */
     public void addTags(Hashtable h){
+        ArrayList<String> keys = new ArrayList<String>();
+        keys.addAll(h.keySet());
+        for (int i=0; i<keys.size(); i++){
+            String k = keys.get(i);
+            if(!osmTags.containsKey(k)) {
+                osmTags.put(k,h.get(k));
+            }
+        }
+    }
+
+    public void addTags(Map h){
         ArrayList<String> keys = new ArrayList<String>();
         keys.addAll(h.keySet());
         for (int i=0; i<keys.size(); i++){

--- a/GO_Sync/src/main/java/edu/usf/cutr/go_sync/tag_defs.java
+++ b/GO_Sync/src/main/java/edu/usf/cutr/go_sync/tag_defs.java
@@ -8,6 +8,7 @@ public class tag_defs {
 	public final static String GTFS_STOP_ID_KEY = "gtfs_id";
     public final static String GTFS_OPERATOR_KEY = "network";
     public final static String GTFS_NETWORK_KEY  = "agency_name";
+    public final static String GTFS_NETWORK_ID_KEY  = "agency_id";
     public final static String  OSM_NETWORK_KEY  = "network";
     public final static String GTFS_ZONE_KEY  = "zone_id";
     public final static String  OSM_ZONE_KEY  = "transport:zone";
@@ -21,11 +22,11 @@ public class tag_defs {
     public final static String  OSM_ROUTE_NUM   = "ref";
     public final static String GTFS_ROUTE_NAME  = "route_long_name";
     public final static String  OSM_ROUTE_NAME  = "name";
-    public final static String GTFS_COLOUR_KEY  = "route_color";
+    public final static String GTFS_COLOR_KEY   = "route_color";
+    public final static String GTFS_COLOUR_KEY  = "route_colour";
     public final static String  OSM_COLOUR_KEY  = "colour";
     public final static String GTFS_WHEELCHAIR_KEY = "wheelchair_boarding";
     public final static String OSM_WHEELCHAIR_KEY = "wheelchair";
-
 
     public final static String GTFS_STOP_TYPE_KEY  = "location_type";
     public final static String  OSM_STOP_TYPE_KEY  = "public_transport";
@@ -36,8 +37,16 @@ public class tag_defs {
     public final static String GTFS_STOP_URL_KEY  = "stop_url";
     public final static String GTFS_ROUTE_URL_KEY  = "route_url";
     public final static String  OSM_URL_KEY  = "url";
-//
 
+    //https://developers.google.com/transit/gtfs/reference#tripstxt
+    public final static String GTFS_ROUTE_ID_KEY    = "route_id";
+    public final static String GTFS_SERVICE_ID_KEY  = "service_id";
+    public final static String GTFS_TRIP_ID_KEY     = "trip_id";
+    public final static String GTFS_TRIPS_STOP_ID_KEY = "stop_id";
+
+    public enum primative_type {
+        NODE, RELATION, WAY
+    }
 
 }
 


### PR DESCRIPTION
* Add enum (preparation for handling ways)
* Use correct tag for trains
* Add FIXME
* Parse agency.txt using org.apache.commons.csv
* Parse routes.txt header using org.apache.commons.csv
* Parse route.txt entries
* Add time benchmark output
* Parse trips.txt and stop_times.txt using org.apache.commons.csv
* Read stops.txt header using commons-csv
* Read rest of bus stops use commons-csv
* Remove obsolete code
* Fix route string creation
* Get mode tags from routes
* Update Modes
* Performance enhancements
* Upgrade to Java 8
* Use join to create route_ref string
* whitespace cleanup
* Move Pattern compilation out of for loop
* Further Clean-up
* Use HashMap for KeyIndexes